### PR TITLE
Fix "Invalid `<Link>` with `<a>` child"

### DIFF
--- a/components/signin.tsx
+++ b/components/signin.tsx
@@ -4,10 +4,7 @@ const Signin = () => {
   return (
     <>
       <p>
-        Please signed in.{" "}
-        <Link href={"/auth"}>
-          <a>Sign in</a>
-        </Link>
+        Please signed in. <Link href={"/auth"}>Sign in</Link>
       </p>
     </>
   );


### PR DESCRIPTION
Ref: https://nextjs.org/docs/messages/invalid-new-link-with-extra-anchor