### PR TITLE
Fix auth cookie not refreshed when onIdTokenChanged registered after …

### DIFF
--- a/lib/useUser.ts
+++ b/lib/useUser.ts
@@ -11,7 +11,7 @@ import { mapUserData } from "./mapUserData";
 import UserType from "../types/user";
 
 const useUser = () => {
-  const [user, setUser] = useState<UserType>();
+  const [user, setUser] = useState<UserType | undefined>(getUserFromCookie);
   const router = useRouter();
 
   const logout = async () => {
@@ -42,12 +42,9 @@ const useUser = () => {
       }
     });
 
-    const userFromCookie = getUserFromCookie();
-    if (!userFromCookie) {
+    if (!getUserFromCookie()) {
       router.push("/");
-      return;
     }
-    setUser(userFromCookie);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
…cookie check

Register the Firebase onIdTokenChanged listener before checking for the cookie so that Firebase can recreate an expired cookie when the session is still valid. The previous change moved the cookie check before the listener registration with an early return, which prevented Firebase from refreshing the cookie, causing users to be forced to log in every time the 1-hour cookie expired.